### PR TITLE
builder: revert to previous ldcheck feature.

### DIFF
--- a/.github/workflows/Recovery-Builder-PBRP.yml
+++ b/.github/workflows/Recovery-Builder-PBRP.yml
@@ -39,13 +39,9 @@ on:
         - recovery
         - vendorboot
       LDCHECK:
-        description: 'Check or Ignore' # Use it know what kind of dependencies your missing for decryption blobs.
+        description: 'Path of blobs to check' # Use it know what kind of dependencies your missing for decryption blobs.
         required: true
-        default: 'ignore'
-        type: choice
-        options:
-        - check
-        - ignore
+        default: 'system/bin/qseecomd'
 
 jobs:
   build:
@@ -124,7 +120,6 @@ jobs:
             echo "DEVICE_MAKEFILE=omni_${{ github.event.inputs.DEVICE_NAME }}" >> $GITHUB_ENV
         else
             echo "No recovery makefile file found!"
-            exit 1
         fi
       continue-on-error: true
 
@@ -137,7 +132,6 @@ jobs:
             echo "DEPENDENCIES=omni.dependencies" >> $GITHUB_ENV
         else
             echo "No dependencies file found!"
-            exit 1
         fi
       continue-on-error: true
 
@@ -182,36 +176,6 @@ jobs:
           Build: ${{ github.event.inputs.MANIFEST_BRANCH }}
           Device: ${{ github.event.inputs.DEVICE_TREE }}/tree/${{ github.event.inputs.DEVICE_TREE_BRANCH }}
 
-    - name: Detect File (Only if LDCHECK was set to check.)
-      if: github.event.inputs.LDCHECK == 'check'
-      run: |
-        cd android-recovery
-        if [ -f ${{ github.event.inputs.DEVICE_PATH }}/recovery/root/system/bin/qseecomd ]; then
-            echo "FILE_TO_CHECK=system/bin/qseecomd" >> $GITHUB_ENV
-        elif [ -f ${{ github.event.inputs.DEVICE_PATH }}/recovery/root/vendor/bin/qseecomd ]; then
-            echo "FILE_TO_CHECK=vendor/bin/qseecomd" >> $GITHUB_ENV
-        else
-            echo "No qseecomd file found!"
-            exit 1
-        fi
-        if [ -f ${{ github.event.inputs.DEVICE_PATH }}/recovery/root/system/bin/mcDriverDaemon ]; then
-            echo "FILE_TO_CHECK=system/bin/mcDriverDaemon" >> $GITHUB_ENV
-        elif [ -f ${{ github.event.inputs.DEVICE_PATH }}/recovery/root/vendor/bin/mcDriverDaemon ]; then
-            echo "FILE_TO_CHECK=vendor/bin/mcDriverDaemon" >> $GITHUB_ENV
-        else
-            echo "No mcDriverDaemon file found!"
-            exit 1
-        fi
-        if [ -f ${{ github.event.inputs.DEVICE_PATH }}/recovery/root/system/bin/teei_daemon ]; then
-            echo "FILE_TO_CHECK=system/bin/teei_daemon" >> $GITHUB_ENV
-        elif [ -f ${{ github.event.inputs.DEVICE_PATH }}/recovery/root/vendor/bin/teei_daemon ]; then
-            echo "FILE_TO_CHECK=vendor/bin/teei_daemon" >> $GITHUB_ENV
-        else
-            echo "No teei_daemon file found!"
-            exit 1
-        fi
-      continue-on-error: true
-
     - name: Run LDCheck (Only if LDCHECK was set to check.)
       if: github.event.inputs.LDCHECK == 'check'
       run: |
@@ -219,6 +183,6 @@ jobs:
         mv -n libneeds ${GITHUB_WORKSPACE}/android-recovery/out/target/product/${{ github.event.inputs.DEVICE_NAME }}/recovery/root/
         mv -n ldcheck ${GITHUB_WORKSPACE}/android-recovery/out/target/product/${{ github.event.inputs.DEVICE_NAME }}/recovery/root/
         cd ../android-recovery/out/target/product/${{ github.event.inputs.DEVICE_NAME }}/recovery/root
-        python3 ldcheck -p system/lib64:vendor/lib64:system/lib:vendor/lib -d ${{ env.FILE_TO_CHECK }}
+        python3 ldcheck -p system/lib64:vendor/lib64:system/lib:vendor/lib -d ${{ github.event.inputs.DEVICE_NAME }}
         echo "Done checking missing dependencies. Review, and reconfigure your tree."
       continue-on-error: true

--- a/.github/workflows/Recovery-Builder-TWRP.yml
+++ b/.github/workflows/Recovery-Builder-TWRP.yml
@@ -38,13 +38,9 @@ on:
         - recovery
         - vendorboot
       LDCHECK:
-        description: 'Check or Ignore' # Use it know what kind of dependencies your missing for decryption blobs.
+        description: 'Path of blobs to check' # Use it know what kind of dependencies your missing for decryption blobs.
         required: true
-        default: 'ignore'
-        type: choice
-        options:
-        - check
-        - ignore
+        default: 'system/bin/qseecomd'
 
 jobs:
   build:
@@ -131,7 +127,6 @@ jobs:
             echo "DEVICE_MAKEFILE=omni_${{ github.event.inputs.DEVICE_NAME }}" >> $GITHUB_ENV
         else
             echo "No recovery makefile file found!"
-            exit 1
         fi
       continue-on-error: true
 
@@ -144,7 +139,6 @@ jobs:
             echo "DEPENDENCIES=omni.dependencies" >> $GITHUB_ENV
         else
             echo "No dependencies file found!"
-            exit 1
         fi
       continue-on-error: true
 
@@ -190,43 +184,12 @@ jobs:
           Build: ${{ github.event.inputs.MANIFEST_BRANCH }}
           Device: ${{ github.event.inputs.DEVICE_TREE }}/tree/${{ github.event.inputs.DEVICE_TREE_BRANCH }}
 
-    - name: Detect File (Only if LDCHECK was set to check.)
-      if: github.event.inputs.LDCHECK == 'check'
-      run: |
-        cd android-recovery
-        if [ -f ${{ github.event.inputs.DEVICE_PATH }}/recovery/root/system/bin/qseecomd ]; then
-            echo "FILE_TO_CHECK=system/bin/qseecomd" >> $GITHUB_ENV
-        elif [ -f ${{ github.event.inputs.DEVICE_PATH }}/recovery/root/vendor/bin/qseecomd ]; then
-            echo "FILE_TO_CHECK=vendor/bin/qseecomd" >> $GITHUB_ENV
-        else
-            echo "No qseecomd file found!"
-            exit 1
-        fi
-        if [ -f ${{ github.event.inputs.DEVICE_PATH }}/recovery/root/system/bin/mcDriverDaemon ]; then
-            echo "FILE_TO_CHECK=system/bin/mcDriverDaemon" >> $GITHUB_ENV
-        elif [ -f ${{ github.event.inputs.DEVICE_PATH }}/recovery/root/vendor/bin/mcDriverDaemon ]; then
-            echo "FILE_TO_CHECK=vendor/bin/mcDriverDaemon" >> $GITHUB_ENV
-        else
-            echo "No mcDriverDaemon file found!"
-            exit 1
-        fi
-        if [ -f ${{ github.event.inputs.DEVICE_PATH }}/recovery/root/system/bin/teei_daemon ]; then
-            echo "FILE_TO_CHECK=system/bin/teei_daemon" >> $GITHUB_ENV
-        elif [ -f ${{ github.event.inputs.DEVICE_PATH }}/recovery/root/vendor/bin/teei_daemon ]; then
-            echo "FILE_TO_CHECK=vendor/bin/teei_daemon" >> $GITHUB_ENV
-        else
-            echo "No teei_daemon file found!"
-            exit 1
-        fi
-      continue-on-error: true
-
-    - name: Run LDCheck (Only if LDCHECK was set to check.)
-      if: github.event.inputs.LDCHECK == 'check'
+    - name: Run LDCheck
       run: |
         cd tools
         mv -n libneeds ${GITHUB_WORKSPACE}/android-recovery/out/target/product/${{ github.event.inputs.DEVICE_NAME }}/recovery/root/
         mv -n ldcheck ${GITHUB_WORKSPACE}/android-recovery/out/target/product/${{ github.event.inputs.DEVICE_NAME }}/recovery/root/
         cd ../android-recovery/out/target/product/${{ github.event.inputs.DEVICE_NAME }}/recovery/root
-        python3 ldcheck -p system/lib64:vendor/lib64:system/lib:vendor/lib -d ${{ env.FILE_TO_CHECK }}
+        python3 ldcheck -p system/lib64:vendor/lib64:system/lib:vendor/lib -d ${{ github.event.inputs.DEVICE_NAME }}
         echo "Done checking missing dependencies. Review, and reconfigure your tree."
       continue-on-error: true


### PR DESCRIPTION
* Added back the option to put your own blobs (and its full path, relative to recovery/root as main directory.

Example: If you want to check qseecomd in recovery/root/system/bin, just put system/bin/qseecomd as your LDCHECK value.