### PR TITLE
builder-pbrp: Fixed missing fonts while building PRBP.

### DIFF
--- a/.github/workflows/Recovery-Builder-PBRP.yml
+++ b/.github/workflows/Recovery-Builder-PBRP.yml
@@ -133,6 +133,13 @@ jobs:
         cd /usr/bin
         sudo ln -sf python2 python
 
+    - name: Fixed Missing Fonts
+      run: |
+        cd android-recovery
+        cd external/noto-fonts/other
+        wget https://github.com/cd-Crypton/custom-recovery-extras/raw/main/missing-font.zip
+        unzip -o missing-font.zip
+
     - name: Building Image
       run: |
         cd android-recovery


### PR DESCRIPTION
* For some reason, https://github.com/PitchBlackRecoveryProject/android_bootable_recovery/blob/android-12.1/tools/image_generator/ImageGenerator.java include fonts in LANGUAGE_TO_FONT_MAP that doesn't exist in AOSP Source (noto-fonts, android-12.1.0 r4). So I had to do some alternative way to solve this issue.

Bug: Building PitchBlack recovery keeps on failing on some devices (Yeah, only on some device, some were building fine, I don't get why.) Error:
Exception in thread "main" java.io.IOException: Can not find the font file NotoSansEthiopic-Regular for language am
    at com.android.recovery.tools.ImageGenerator.loadFontsByLocale(ImageGenerator.java:399)
    at com.android.recovery.tools.ImageGenerator.createGraphics(ImageGenerator.java:492)
    at com.android.recovery.tools.ImageGenerator.measureTextWidth(ImageGenerator.java:500)
    at com.android.recovery.tools.ImageGenerator.generateImage(ImageGenerator.java:618)
    at com.android.recovery.tools.ImageGenerator.main(ImageGenerator.java:755)
10:05:28 ninja failed with: exit status 1
Fix: Import all the missing fonts.
Status: Build successful.